### PR TITLE
Extend answers for ambuiguity

### DIFF
--- a/game.js
+++ b/game.js
@@ -1222,7 +1222,7 @@ const levels = [
             },
             {
                 question: "<img src='additional-emojis/foot-sole.png'>",
-                answers: ["sole"]
+                answers: ["sole", "soul"]
             },
             {
                 question: "<img src='additional-emojis/heel-pain.png'>",
@@ -1310,7 +1310,7 @@ const levels = [
             },
             {
                 question: "<img src='additional-emojis/toe.png'>",
-                answers: ["toe"]
+                answers: ["toe", "two"]
             },
             {
                 question: "<img src='additional-emojis/paw.png'>",


### PR DESCRIPTION
Since speech recognition is not perfect, we extend possible answers for words which are hardly discernible ("sole" vs "soul").