### PR TITLE
Ignore exceptions on re-starts of speech

### DIFF
--- a/game.js
+++ b/game.js
@@ -2199,7 +2199,16 @@ class DialoguePlay {
                 systemState.speechRecognition.onstart = oldOnStart;
             }
 
-            systemState.speechRecognition.start();
+            try {
+                systemState.speechRecognition.start();
+            } catch(error) {
+                console.log(
+                    "The speech recognition failed to start: ",
+                    error,
+                    "We are going to silently continue as if it started."
+                );
+            }
+
         }
 
         promiseToRevealCorrectAnswer(card.answers[0])


### PR DESCRIPTION
When we re-start the speech recognition, sometimes it already started, so we simply ignore the exceptions. This is a band-aid, but there seems to be no particularly good solution.