### PR TITLE
Add additional misspellings to "galley"

### DIFF
--- a/game.js
+++ b/game.js
@@ -1101,7 +1101,7 @@ const levels = [
             },
             {
                 question: "<img src='additional-emojis/galley.png'>",
-                answers: ["galley"]
+                answers: ["galley", "helly", "golly"]
             },
             {
                 question: "<img src='additional-emojis/fleet.png'>",


### PR DESCRIPTION
The children pronounced the word "galley" almost perfectly, but the speech recognition probably lacks enough samples. So we add a couple of misrecognized words to the possible answers.